### PR TITLE
detect extention with radix-tree

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,87 @@
+package magic
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"path"
+	"strings"
+	"testing"
+)
+
+type File struct {
+	Extension string
+	Bytes     []byte
+}
+
+func BenchmarkDetectExtensionWithLoop(b *testing.B) {
+	b.StopTimer()
+	files := readFiles()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		for _, f := range files {
+			ext := detectWithLoop(f.Bytes)
+			if f.Extension != ext {
+				errMsg := fmt.Sprintf("Detect with loop missed: %s, %s", f.Extension, ext)
+				panic(errMsg)
+			}
+		}
+	}
+}
+
+func BenchmarkDetectExtension(b *testing.B) {
+	b.StopTimer()
+	files := readFiles()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		for _, f := range files {
+			ext := DetectExtension(f.Bytes)
+			if f.Extension != ext {
+				errMsg := fmt.Sprintf("Detect Extension missed: %s, %s", f.Extension, ext)
+				panic(errMsg)
+			}
+		}
+	}
+}
+
+func readFiles() []*File {
+	d, err := ioutil.ReadDir(sampleDir)
+	if err != nil {
+		panic(err)
+	}
+
+	files := make([]*File, len(d))
+
+	for i, f := range d {
+		b, err := ioutil.ReadFile(path.Join(sampleDir, f.Name()))
+		if err != nil {
+			panic(err)
+		}
+		fnameFactor := strings.Split(f.Name(), ".")
+		sampleExt := fnameFactor[len(fnameFactor)-1]
+		switch sampleExt {
+		case "docx", "xlsx", "pptx":
+			sampleExt = "zip"
+		case "txt":
+			sampleExt = ""
+		default:
+		}
+		f := &File{Extension: sampleExt, Bytes: b}
+		files[i] = f
+	}
+	return files
+}
+
+func detectWithLoop(b []byte) string {
+defLoop:
+	for _, d := range Definitions {
+		for _, s := range d.Signatures {
+			sigLen := len(s.b)
+			if len(b) < s.Offset+sigLen || !bytes.Equal(b[s.Offset:s.Offset+sigLen], s.b) {
+				continue defLoop
+			}
+		}
+		return d.Extension
+	}
+	return ""
+}

--- a/signature.go
+++ b/signature.go
@@ -1,7 +1,6 @@
 package magic
 
 import (
-	"bytes"
 	"strconv"
 	"strings"
 )
@@ -90,7 +89,7 @@ type Definition struct {
 	Signatures []*Signature
 }
 
-func (d *Definition) parse() error {
+func (d *Definition) Parse() error {
 	for _, s := range d.Signatures {
 		if err := s.parse(); err != nil {
 			return err
@@ -119,17 +118,7 @@ func (s *Signature) parse() error {
 }
 
 func DetectExtension(b []byte) string {
-defLoop:
-	for _, d := range Definitions {
-		for _, s := range d.Signatures {
-			sigLen := len(s.b)
-			if len(b) < s.Offset+sigLen || !bytes.Equal(b[s.Offset:s.Offset+sigLen], s.b) {
-				continue defLoop
-			}
-		}
-		return d.Extension
-	}
-	return ""
+	return NODE.Match(b)
 }
 
 func DetectMIME(b []byte) string {
@@ -141,9 +130,11 @@ func DetectMIME(b []byte) string {
 }
 
 func init() {
+	NODE = &Node{}
 	for _, d := range Definitions {
-		if err := d.parse(); err != nil {
+		if err := d.Parse(); err != nil {
 			panic(err)
 		}
+		NODE.Insert(d)
 	}
 }

--- a/tree.go
+++ b/tree.go
@@ -1,0 +1,152 @@
+package magic
+
+import (
+	"bytes"
+	"errors"
+)
+
+var (
+	NODE           *Node
+	ErrNoSignature = errors.New("No signatures in definition")
+)
+
+type Node struct {
+	Signature []byte
+	Offset    int
+	Extension string
+	Children  []*Node
+}
+
+func (n *Node) Insert(d *Definition) {
+	d = copyDefinition(d)
+	if len(d.Signatures) == 0 {
+		return
+	}
+
+	for {
+		if n.Signature == nil && n.Children == nil {
+			n.Signature = d.Signatures[0].b
+			n.Offset = d.Signatures[0].Offset
+			if len(d.Signatures) > 1 {
+				child := &Node{}
+				n.Children = append(n.Children, child)
+				n = child
+				d.Signatures = d.Signatures[1:]
+				continue
+			}
+			n.Extension = d.Extension
+			return
+		}
+
+		i := n.commonLength(d.Signatures[0].b)
+
+		// Split edge
+		if i < len(n.Signature) {
+			child := &Node{
+				Signature: n.Signature[i:],
+				Offset:    n.Offset + i,
+				Children:  n.Children,
+				Extension: n.Extension,
+			}
+			n.Signature = n.Signature[:i]
+			n.Extension = ""
+			n.Children = []*Node{child}
+		}
+
+		// Add a child
+		if i < len(d.Signatures[0].b) {
+			child := n.findChildBySignature(d.Signatures[0])
+			if child == nil {
+				d.Signatures[0].b = d.Signatures[0].b[i:]
+				d.Signatures[0].Offset += i
+				child = &Node{}
+				n.Children = append(n.Children, child)
+			}
+			n = child
+		} else if i == len(d.Signatures[0].b) {
+			if len(d.Signatures) == 1 {
+				n.Extension = d.Extension
+				return
+			}
+			d.Signatures = d.Signatures[1:]
+			child := n.findChildBySignature(d.Signatures[0])
+			if child == nil {
+				child = &Node{Offset: d.Signatures[0].Offset}
+				n.Children = append(n.Children, child)
+			}
+			n = child
+		}
+	}
+}
+
+func (n *Node) Match(b []byte) string {
+	return n.match(b[n.Offset:])
+}
+
+func (n *Node) match(b []byte) (Extension string) {
+	if !bytes.HasPrefix(b, n.Signature) {
+		return
+	}
+
+	for _, child := range n.Children {
+		offset := child.Offset - n.Offset
+		child := n.findChild(b)
+		if child == nil {
+			return n.Extension
+		}
+		Extension = child.match(b[offset:])
+		if Extension != "" {
+			return
+		}
+	}
+	return n.Extension
+}
+
+func (n *Node) commonLength(b []byte) (i int) {
+	limit := len(n.Signature)
+	if x := len(b); x < limit {
+		limit = x
+	}
+	for i < limit && n.Signature[i] == b[i] {
+		i++
+	}
+	return
+}
+
+func (n *Node) findChild(b []byte) *Node {
+	for _, child := range n.Children {
+		offset := child.Offset - n.Offset
+		if len(b) >= offset+len(child.Signature) && b[offset] == child.Signature[0] {
+			return child
+		}
+	}
+	return nil
+}
+
+func (n *Node) findChildBySignature(s *Signature) *Node {
+	for _, child := range n.Children {
+		if child.Offset == s.Offset && child.Signature[0] == s.b[0] {
+			return child
+		}
+	}
+	return nil
+}
+
+func copyDefinition(src *Definition) *Definition {
+	return &Definition{
+		Extension:  src.Extension,
+		Signatures: copySignatures(src.Signatures),
+	}
+}
+
+func copySignatures(src []*Signature) (dst []*Signature) {
+	dst = make([]*Signature, len(src))
+	for i, s := range src {
+		dst[i] = &Signature{
+			Offset: s.Offset,
+			Bytes:  s.Bytes,
+			b:      s.b,
+		}
+	}
+	return
+}

--- a/tree_test.go
+++ b/tree_test.go
@@ -1,0 +1,174 @@
+package magic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNode(t *testing.T) {
+	n := &Node{}
+
+	// Test inserting
+	d := &Definition{
+		Extension: "ext1",
+		Signatures: []*Signature{
+			&Signature{Offset: 0, b: []byte("prefix1")},
+		},
+	}
+	n.Insert(d)
+	expect := &Node{
+		Signature: []byte("prefix1"),
+		Extension: "ext1",
+	}
+	assert.Equal(t, expect, n)
+
+	d = &Definition{
+		Extension: "ext2",
+		Signatures: []*Signature{
+			&Signature{Offset: 0, b: []byte("prefix1")},
+			&Signature{Offset: 10, b: []byte("prefix2")},
+		},
+	}
+	n.Insert(d)
+	child := &Node{
+		Signature: []byte("prefix2"),
+		Offset:    10,
+		Extension: "ext2",
+	}
+	expect.Children = []*Node{child}
+	assert.Equal(t, expect, n)
+
+	d = &Definition{
+		Extension: "ext3",
+		Signatures: []*Signature{
+			&Signature{Offset: 0, b: []byte("prefix1")},
+			&Signature{Offset: 10, b: []byte("prefix3")},
+		},
+	}
+	n.Insert(d)
+	child2 := &Node{
+		Signature: []byte("2"),
+		Offset:    16,
+		Extension: "ext2",
+	}
+	child3 := &Node{
+		Signature: []byte("3"),
+		Offset:    16,
+		Extension: "ext3",
+	}
+	child1 := &Node{
+		Signature: []byte("prefix"),
+		Offset:    10,
+		Extension: "",
+		Children:  []*Node{child2, child3},
+	}
+	expect = &Node{
+		Signature: []byte("prefix1"),
+		Extension: "ext1",
+		Children:  []*Node{child1},
+	}
+	assert.Equal(t, expect, n)
+
+	d = &Definition{
+		Extension: "ext0",
+		Signatures: []*Signature{
+			&Signature{Offset: 0, b: []byte("pref")},
+		},
+	}
+	n.Insert(d)
+	child2 = &Node{
+		Signature: []byte("2"),
+		Offset:    16,
+		Extension: "ext2",
+	}
+	child3 = &Node{
+		Signature: []byte("3"),
+		Offset:    16,
+		Extension: "ext3",
+	}
+	child1 = &Node{
+		Signature: []byte("prefix"),
+		Offset:    10,
+		Extension: "",
+		Children:  []*Node{child2, child3},
+	}
+	child0 := &Node{
+		Signature: []byte("ix1"),
+		Offset:    4,
+		Extension: "ext1",
+		Children:  []*Node{child1},
+	}
+	expect = &Node{
+		Signature: []byte("pref"),
+		Extension: "ext0",
+		Children:  []*Node{child0},
+	}
+	assert.Equal(t, expect, n)
+
+	d = &Definition{
+		Extension: "ext10",
+		Signatures: []*Signature{
+			&Signature{Offset: 0, b: []byte("orefix1")},
+		},
+	}
+	n.Insert(d)
+	child2 = &Node{
+		Signature: []byte("2"),
+		Offset:    16,
+		Extension: "ext2",
+	}
+	child3 = &Node{
+		Signature: []byte("3"),
+		Offset:    16,
+		Extension: "ext3",
+	}
+	child1 = &Node{
+		Signature: []byte("prefix"),
+		Offset:    10,
+		Extension: "",
+		Children:  []*Node{child2, child3},
+	}
+	child0 = &Node{
+		Signature: []byte("ix1"),
+		Offset:    4,
+		Extension: "ext1",
+		Children:  []*Node{child1},
+	}
+	child = &Node{
+		Signature: []byte("pref"),
+		Extension: "ext0",
+		Children:  []*Node{child0},
+	}
+	brother := &Node{
+		Signature: []byte("orefix1"),
+		Extension: "ext10",
+	}
+	expect = &Node{
+		Signature: []byte{},
+		Children:  []*Node{child, brother},
+	}
+	assert.Equal(t, expect, n)
+
+	// Test matching
+	data := []byte("prefix1")
+	assert.Equal(t, "ext1", n.Match(data))
+
+	data = []byte("prefix1foo")
+	assert.Equal(t, "ext1", n.Match(data))
+
+	data = []byte("prefix1789prefix2")
+	assert.Equal(t, "ext2", n.Match(data))
+
+	data = []byte("prefix1789prefix3")
+	assert.Equal(t, "ext3", n.Match(data))
+
+	data = []byte("prefix3")
+	assert.Equal(t, "ext0", n.Match(data))
+
+	data = []byte("orefix1")
+	assert.Equal(t, "ext10", n.Match(data))
+
+	data = []byte("foobaa")
+	assert.Equal(t, "", n.Match(data))
+}


### PR DESCRIPTION
usage: 
```go
d := &magic.Definition{
    Extension: "ext1",
    Signatures: []*magic.Signature{&magic.Signature{
        Offset: 0,
        Bytes:  "61 62 63 64",
    }},
}

if err := d.Parse(); err != nil {
    panic(err)
}

n := &magic.Node{}
n.Insert(d)

fmt.Println(n.Match([]byte("abcde")))   // "ext1"
fmt.Println(n.Match([]byte("cdefg")))   // ""
````

benchmark:
```bash
$ go test -bench .
PASS
BenchmarkDetectExtensionWithLoop          200000              6000 ns/op   # Old function
BenchmarkDetectExtension         1000000              2203 ns/op           # New function
ok      github.com/jakoknb/go-magic     3.533s
```